### PR TITLE
Fix: Undisclosed emails shouldn't be emitted.

### DIFF
--- a/agent/result_parser.py
+++ b/agent/result_parser.py
@@ -15,6 +15,8 @@ OPTIONAL_FIELDS = [
     "country",
 ]
 
+UNDISCLOSED_VALUE = "<data not disclosed>"
+
 
 def parse_results(results: whois.parser.WhoisCom) -> Iterator[Dict[str, Any]]:
     """Parses whois_domain scan results.
@@ -43,9 +45,7 @@ def parse_results(results: whois.parser.WhoisCom) -> Iterator[Dict[str, Any]]:
                 ),
                 "name": name,
                 "emails": get_list_from_string(
-                    scan_output_dict.get("email", "")
-                    if scan_output_dict.get("email", "") != ""
-                    else scan_output_dict.get("emails", "")
+                    scan_output_dict.get("email") or scan_output_dict.get("emails", "")
                 ),
                 "status": get_list_from_string(scan_output_dict.get("status", "")),
                 "name_servers": get_list_from_string(
@@ -96,6 +96,8 @@ def get_list_from_string(scan_output_value: Union[str, List[str]]) -> List[str]:
        A list from the scan_output_value.
     """
     if isinstance(scan_output_value, str):
+        if scan_output_value == UNDISCLOSED_VALUE:
+            return []
         return [scan_output_value]
     else:
         return scan_output_value or []

--- a/requirement.txt
+++ b/requirement.txt
@@ -2,3 +2,4 @@ ostorlab[agent]
 rich
 python-whois
 tld
+email-validator

--- a/tests/whois_domain_agent_test.py
+++ b/tests/whois_domain_agent_test.py
@@ -394,7 +394,7 @@ def testAgentWhois_whenEmailIsNotDisclosed_shouldNotEmitEmails(
     test_agent: whois_domain_agent.AgentWhoisDomain,
     mocker: plugin.MockerFixture,
     agent_persist_mock: Any,
-    agent_mock: List[message.Message],
+    agent_mock: list[message.Message],
 ) -> None:
     del agent_persist_mock
     mocker.patch(

--- a/tests/whois_domain_agent_test.py
+++ b/tests/whois_domain_agent_test.py
@@ -388,3 +388,26 @@ def testAgentWhois_whenDifferentSubdomainsRecevied_onlyFldIsProcessed(
     assert len(agent_mock) > 0
     assert agent_mock[0].selector == "v3.asset.domain_name.whois"
     assert agent_mock[0].data["name"] == "test.ostorlab.co"
+
+
+def testAgentWhois_whenEmailIsNotDisclosed_shouldNotEmitEmails(
+    test_agent: whois_domain_agent.AgentWhoisDomain,
+    mocker: plugin.MockerFixture,
+    agent_persist_mock: Any,
+    agent_mock: List[message.Message],
+) -> None:
+    del agent_persist_mock
+    mocker.patch(
+        "whois.whois", return_value={**SCAN_OUTPUT, "email": "<data not disclosed>"}
+    )
+
+    test_agent.process(
+        message.Message.from_data(
+            "v3.asset.domain_name",
+            data={
+                "name": "test.co",
+            },
+        )
+    )
+
+    assert agent_mock[0].data.get("emails") is None


### PR DESCRIPTION
There are some domains where the email is not public.
in this case we shouldn't emit this value.

This caused a bug in autodiscovery_persist. since we can't create a node with this invalid value.

This is a scan output for the domain that caused the issue. 

![image](https://github.com/Ostorlab/agent_whois_domain/assets/144700714/3c5155fb-d6fd-4a48-b80f-7d3b7998c25f)
