### PR TITLE
Fix electrohold invalid TLD.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,16 @@ def scan_message() -> message.Message:
 
 
 @pytest.fixture
+def electro_scan_message() -> message.Message:
+    """Creates a dummy message of type v3.asset.domain_name to be used by the agent for testing purposes."""
+    selector = "v3.asset.domain_name"
+    msg_data = {
+        "name": "electrohold.bg",
+    }
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture
 def test_agent() -> whois_domain_agent.AgentWhoisDomain:
     """Creates a dummy agent for the Whois Domain Agent."""
 

--- a/tests/whois_domain_agent_test.py
+++ b/tests/whois_domain_agent_test.py
@@ -412,3 +412,21 @@ def testAgentWhois_whenEmailIsNotDisclosed_shouldNotEmitEmails(
     )
 
     assert agent_mock[0].data.get("emails") is None
+
+
+def testAgentWhois_whenDomainNameAssetInvalidTLD_emitsMessages(
+    electro_scan_message: message.Message,
+    test_agent: whois_domain_agent.AgentWhoisDomain,
+    agent_persist_mock: Any,
+    mocker: plugin.MockerFixture,
+    agent_mock: List[message.Message],
+) -> None:
+    """Tests running the agent and emitting vulnerabilities."""
+    del agent_persist_mock
+
+    test_agent.start()
+    test_agent.process(electro_scan_message)
+
+    assert len(agent_mock) > 0
+    assert agent_mock[0].selector == "v3.asset.domain_name.whois"
+    assert "electrohold.bg" in agent_mock[0].data["name"]


### PR DESCRIPTION
The issue seems to be addressed in newer version of TLD. Added unit test verifying the fix.