### PR TITLE
Retry whois command on timeout to prevent crashes  

### DIFF
--- a/agent/whois_domain_agent.py
+++ b/agent/whois_domain_agent.py
@@ -99,7 +99,9 @@ class AgentWhoisDomain(agent.Agent, persist_mixin.AgentPersistMixin):
     @tenacity.retry(
         stop=tenacity.stop_after_attempt(RETRY_NUMBER),
         wait=tenacity.wait_fixed(WAIT_TIME),
-        retry=tenacity.retry_if_exception_type((socket.gaierror, ConnectionResetError)),
+        retry=tenacity.retry_if_exception_type(
+            (socket.gaierror, ConnectionResetError, TimeoutError)
+        ),
         retry_error_callback=lambda retry_state: None,
     )
     def _fetch_whois(self, domain_name: str) -> whois.parser.WhoisCom | None:

--- a/tests/whois_domain_agent_test.py
+++ b/tests/whois_domain_agent_test.py
@@ -451,6 +451,22 @@ def testAgentWhois_whenConnectionError_shouldRetry(
     assert mock_whois.call_count == 3
 
 
+def testAgentWhois_whenTimeoutError_shouldRetry(
+    scan_message: message.Message,
+    test_agent: whois_domain_agent.AgentWhoisDomain,
+    agent_persist_mock: Any,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Tests running the agent shouldn't crash when timeout error occur."""
+    del agent_persist_mock
+    mocker.patch("time.sleep")
+    mock_whois = mocker.patch("whois.whois", side_effect=TimeoutError)
+
+    test_agent.process(scan_message)
+
+    assert mock_whois.call_count == 3
+
+
 def testAgentWhois_whenWhoisUnicodeError_doesNotCrash(
     scan_message_bad_character: message.Message,
     test_agent: whois_domain_agent.AgentWhoisDomain,


### PR DESCRIPTION
This PR introduces a retry mechanism for the `whois` command when it fails due to a timeout error.  

### Issue in Production  

![image](https://github.com/user-attachments/assets/ff130d11-6d81-409b-8ff7-6f1de400b2f7)  

### Changes & Fixes  

- The `whois` command will now retry up to **3 times** in case of a timeout.  
- If the host remains unresponsive after the retries, it will be skipped instead of causing a crash.  

This ensures better resilience and prevents failures due to transient network issues.  

### Related Ticket  

🔗 [[OS-11134](https://report.ostorlab.co/remediation/tickets/os-11134)](https://report.ostorlab.co/remediation/tickets/os-11134)  