### PR TITLE
feature: Add semantic-pull-request GitHub Action `agent_whois_domain`

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,25 @@
+name: "Validate PR Title"
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+permissions:
+  pull-requests: write
+  statuses: write
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          wip: true
+          types: |
+            feature
+            fix
+            documentation


### PR DESCRIPTION
## Adds Semantic-pull-request Action

This PR adds the semantic-pull-request GitHub Action to enforce Conventional Commits formatting for PR titles.

**Key Features**:

    - Provides automated validation of PR titles
    - Supports [WIP] prefix for work in progress

The action validates PR titles against patterns like: feat:, fix:, docs:, refactor:, test:, ci:, chore:

**Action**: https://github.com/amannn/action-semantic-pull-request