### PR TITLE
fix: parser exception

### DIFF
--- a/agent/whois_domain_agent.py
+++ b/agent/whois_domain_agent.py
@@ -14,6 +14,7 @@ from ostorlab.agent.mixins import agent_persist_mixin as persist_mixin
 from ostorlab.runtimes import definitions as runtime_definitions
 from rich import logging as rich_logging
 from whois import parser
+from whois import exceptions as whois_exceptions
 
 from agent import result_parser
 
@@ -76,7 +77,7 @@ class AgentWhoisDomain(agent.Agent, persist_mixin.AgentPersistMixin):
                 if scan_output is None:
                     return
                 self._emit_result(scan_output)
-            except parser.PywhoisError as e:
+            except whois_exceptions.PywhoisError as e:
                 logger.error(e)
         else:
             logger.error("domain is not a valid URL: %s", domain)

--- a/agent/whois_domain_agent.py
+++ b/agent/whois_domain_agent.py
@@ -13,7 +13,6 @@ from ostorlab.agent.message import message as msg
 from ostorlab.agent.mixins import agent_persist_mixin as persist_mixin
 from ostorlab.runtimes import definitions as runtime_definitions
 from rich import logging as rich_logging
-from whois import parser
 from whois import exceptions as whois_exceptions
 
 from agent import result_parser

--- a/tests/whois_domain_agent_test.py
+++ b/tests/whois_domain_agent_test.py
@@ -6,6 +6,7 @@ from typing import List, Any
 import pytest
 from ostorlab.agent.message import message
 from pytest_mock import plugin
+from whois import exceptions as whois_exceptions
 
 from agent import whois_domain_agent
 
@@ -509,7 +510,9 @@ def testAgentWhois_whenPywhoisError_logsError(
     del agent_persist_mock
     mocker.patch(
         "whois.whois",
-        side_effect=whois_domain_agent.whois_exceptions.PywhoisError("Error message produced by whois exception"),
+        side_effect=whois_exceptions.PywhoisError(
+            "Error message produced by whois exception"
+        ),
     )
 
     test_agent.start()

--- a/tests/whois_domain_agent_test.py
+++ b/tests/whois_domain_agent_test.py
@@ -530,8 +530,9 @@ def testAgentWhois_whenFetchWhoisReturnsNone_returnsEarly(
 ) -> None:
     """The agent should return early when fetch_whois returns None."""
     del agent_persist_mock
-    mocker.patch.object(
-        whois_domain_agent.AgentWhoisDomain, "_fetch_whois", return_value=None
+    mocker.patch(
+        "whois.whois",
+        side_effect=None,
     )
 
     test_agent.start()

--- a/tests/whois_domain_agent_test.py
+++ b/tests/whois_domain_agent_test.py
@@ -498,6 +498,45 @@ def testAgentWhois_whenTimeoutError_shouldRetry(
     assert mock_whois.call_count == 3
 
 
+def testAgentWhois_whenPywhoisError_logsError(
+    scan_message: message.Message,
+    test_agent: whois_domain_agent.AgentWhoisDomain,
+    agent_persist_mock: Any,
+    mocker: plugin.MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The agent should not crash when PywhoisError occurs and should log the error."""
+    del agent_persist_mock
+    mocker.patch(
+        "whois.whois",
+        side_effect=whois_domain_agent.whois_exceptions.PywhoisError("Error message produced by whois exception"),
+    )
+
+    test_agent.start()
+    test_agent.process(scan_message)
+
+    assert "Error message produced by whois exception" in caplog.text
+
+
+def testAgentWhois_whenFetchWhoisReturnsNone_returnsEarly(
+    scan_message: message.Message,
+    test_agent: whois_domain_agent.AgentWhoisDomain,
+    agent_persist_mock: Any,
+    mocker: plugin.MockerFixture,
+    agent_mock: List[message.Message],
+) -> None:
+    """The agent should return early when fetch_whois returns None."""
+    del agent_persist_mock
+    mocker.patch.object(
+        whois_domain_agent.AgentWhoisDomain, "_fetch_whois", return_value=None
+    )
+
+    test_agent.start()
+    test_agent.process(scan_message)
+
+    assert len(agent_mock) == 0
+
+
 def testAgentWhois_whenWhoisUnicodeError_doesNotCrash(
     scan_message_bad_character: message.Message,
     test_agent: whois_domain_agent.AgentWhoisDomain,

--- a/tests/whois_domain_agent_test.py
+++ b/tests/whois_domain_agent_test.py
@@ -532,7 +532,7 @@ def testAgentWhois_whenFetchWhoisReturnsNone_returnsEarly(
     del agent_persist_mock
     mocker.patch(
         "whois.whois",
-        side_effect=None,
+        return_value=None,
     )
 
     test_agent.start()


### PR DESCRIPTION
## Changes

- in parser package the `PywhoisError` class is moved from `parser` module to `exceptions`

<img width="1207" height="256" alt="image" src="https://github.com/user-attachments/assets/397d986c-bd3c-4767-8593-4761c9253ce9" />
